### PR TITLE
Fix unit tests.

### DIFF
--- a/test/unit/resources/scripts/conference.js
+++ b/test/unit/resources/scripts/conference.js
@@ -12,10 +12,10 @@ describe('Unit tests for ConferenceClient', function() {
     it(
       'Create a ConferenceClient with or without configuration should success.',
       done => {
-        let confclient = new ConferenceClient({}, {});
-        expect(confclient).to.be.an.instanceof(ConferenceClient);
-        confclient = new ConferenceClient({},{});
-        expect(confclient).to.be.an.instanceof(ConferenceClient);
+        let confclient = new ConferenceClient({});
+        expect(confclient).to.be.an.instanceof(EventModule.EventDispatcher);
+        confclient = new ConferenceClient({});
+        expect(confclient).to.be.an.instanceof(EventModule.EventDispatcher);
         done();
       });
 
@@ -28,7 +28,7 @@ describe('Unit tests for ConferenceClient', function() {
       conf2.addEventListener('test', () => {
         done();
       });
-      conf2.dispatchEvent(new EventModule.IcsEvent('test'));
+      conf2.dispatchEvent(new EventModule.OmsEvent('test'));
     });
   });
 });

--- a/test/unit/resources/scripts/fake-p2p-signaling.js
+++ b/test/unit/resources/scripts/fake-p2p-signaling.js
@@ -23,14 +23,18 @@ export default class FakeP2PSignalingChannel {
   };
 
   send(targetId, message) {
-    Logger.debug(this.userId+' -> '+targetId+': '+message);
-    if (onMessageHandlers.has(targetId)) {
-      setTimeout(() => {
-        onMessageHandlers.get(targetId)(this.userId, message)
-      }, 0);;
-    } else {
-      console.error('Cannot send to message to ' + targetId);
-    }
+    Logger.debug(this.userId + ' -> ' + targetId + ': ' + message);
+    return new Promise((resolve, reject) => {
+      if (onMessageHandlers.has(targetId)) {
+        setTimeout(() => {
+          onMessageHandlers.get(targetId)(this.userId, message)
+          return resolve();
+        }, 0);;
+      } else {
+        console.error('Cannot send to message to ' + targetId);
+        return reject();
+      }
+    })
   };
 
   connect(loginInfo) {

--- a/test/unit/resources/scripts/p2p.js
+++ b/test/unit/resources/scripts/p2p.js
@@ -2,6 +2,7 @@
 import P2PClient from '../../../../src/sdk/p2p/p2pclient.js';
 import SignalingChannel from './fake-p2p-signaling.js';
 import * as StreamModule from '../../../../src/sdk/base/stream.js';
+import * as EventModule from '../../../../src/sdk/base/event.js'
 
 const expect = chai.expect;
 const screenSharingExtensionId = 'jniliohjdiikfjjdlpapmngebedgigjn';
@@ -12,9 +13,9 @@ describe('Unit tests for P2PClient', function() {
       'Create a P2PClient with or without configuration should success.',
       done => {
         let p2pclient = new P2PClient({}, {});
-        expect(p2pclient).to.be.an.instanceof(P2PClient);
+        expect(p2pclient).to.be.an.instanceof(EventModule.EventDispatcher);
         p2pclient = new P2PClient({},{});
-        expect(p2pclient).to.be.an.instanceof(P2PClient);
+        expect(p2pclient).to.be.an.instanceof(EventModule.EventDispatcher);
         done();
       });
   });
@@ -56,7 +57,8 @@ describe('Unit tests for P2PClient', function() {
     it(
       'Disconnect from signaling server before connected should be rejected.',
       done => {
-        expect(p2pclient.disconnect()).to.be.rejected.and.notify(done);
+        expect(p2pclient.disconnect()).to.be.undefined;
+        done();
       });
   });
   describe('Interop with remote endpoints', function(){
@@ -103,7 +105,8 @@ describe('Unit tests for P2PClient', function() {
         p2pclient1.getStats('user2').then((stats)=>{
           console.info('Stats: '+JSON.stringify(stats));
         });
-        expect(publication.stop()).to.be.fulfilled.and.notify(done);
+        expect(publication.stop()).to.be.undefined;
+        done();
       });
     });
     it(


### PR DESCRIPTION
- Some APIs has been changed to return undefined.
- Currently, P2PClient and ConferenceClient's prototype is EventDispatcher.
- FakeP2PSignalingChannel's send method returns a promise.