### PR TITLE
suggest to add default iceServers

### DIFF
--- a/src/sdk/conference/channel.js
+++ b/src/sdk/conference/channel.js
@@ -590,6 +590,7 @@ export class ConferencePeerConnectionChannel extends EventDispatcher {
     if (Utils.isChrome()) {
       pcConfiguration.sdpSemantics = 'unified-plan';
     }
+    pcConfiguration.iceServers = pcConfiguration.iceServers || [{urls: "stun:stun.l.google.com:19302"}];
     this._pc = new RTCPeerConnection(pcConfiguration);
     this._pc.onicecandidate = (event) => {
       this._onLocalIceCandidate.apply(this, [event]);


### PR DESCRIPTION
There is a bug.
I open https://192.168.84.99:3004/ in firefox firstly,  then open https://192.168.84.99:3004/ in my safari V12.0.
Found that I cann't watch any user in safari, but I can watch both in firefox.
When I add this iceServer, they can see both.