### PR TITLE
Re-enable grunt debug.

### DIFF
--- a/scripts/Gruntfile.js
+++ b/scripts/Gruntfile.js
@@ -261,5 +261,6 @@ window.L = L;\n\
   grunt.registerTask('prepare', ['browserify:sinon', 'browserify:chai_as_promised']);
   grunt.registerTask('pack', ['browserify:dist', 'concat:rest', 'uglify:dist', 'copy:dist', 'string-replace', 'compress:dist', 'jsdoc:dist']);
   grunt.registerTask('dev', ['browserify:dev', 'connect:server']);
+  grunt.registerTask('debug', ['browserify:dev']);
   grunt.registerTask('default', ['pack']);
 };


### PR DESCRIPTION
This command was supported in old versions, but replaced by `grunt dev` in 4.x. It still useful when a debug version of SDK is need.

Fix #148 and #319.