### PR TITLE
Add a Mute toggle for remote audio stream

### DIFF
--- a/src/samples/p2p/js/peercall.js
+++ b/src/samples/p2p/js/peercall.js
@@ -53,6 +53,11 @@ $(document).ready(function() {
     p2p.allowedRemoteIds = [getTargetId()];
   });
 
+  $('#mute-toggle').click(function () {
+    document.getElementById('remoteVideo').muted = !document.getElementById('remoteVideo').muted;
+    document.getElementById('screenVideo').muted = !document.getElementById('screenVideo').muted;
+  });
+
   $('#target-screen').click(function() {
     const config = {
       audio: {

--- a/src/samples/p2p/peercall.html
+++ b/src/samples/p2p/peercall.html
@@ -90,6 +90,9 @@
       <button id="target-video-unpublish">Stop Camera Sharing</button>
       <button id="target-peerconnection-stop">Stop Conversation</button>
       <button id="target-screen">Share Screen</button>
+      <br>
+      <br>
+      <button id="mute-toggle">Mute/Unmute</button>
     </p>
   </div>
   <div id="sendreceive">


### PR DESCRIPTION
Remote stream is muted by default. This is a little confusion as audio will not work without manually changing the demo's HTML. 
Alternative is to provide explicit muting controls. That could be an overkill as audio can be easily muted on the system.