### PR TITLE
Fix an issue to prevent from lossing cached remote ICE candidates.

### DIFF
--- a/src/sdk/p2p/peerconnection-channel.js
+++ b/src/sdk/p2p/peerconnection-channel.js
@@ -571,9 +571,11 @@ class P2PPeerConnectionChannel extends EventDispatcher {
 
   _onSignalingStateChange(event) {
     Logger.debug('Signaling state changed: ' + this._pc.signalingState);
-    if (this._pc.signalingState === 'closed') {
-      // stopChatLocally(peer, peer.id);
-    } else if (this._pc.signalingState === 'stable') {
+    if (this._pc.signalingState === 'have-remote-offer' ||
+        this._pc.signalingState === 'stable') {
+      this._drainPendingRemoteIceCandidates();
+    }
+    if (this._pc.signalingState === 'stable') {
       this._negotiating = false;
       if (this._isNegotiationNeeded) {
         this._onNegotiationneeded();
@@ -581,8 +583,6 @@ class P2PPeerConnectionChannel extends EventDispatcher {
         this._drainPendingStreams();
         this._drainPendingMessages();
       }
-    } else if (this._pc.signalingState === 'have-remote-offer') {
-      this._drainPendingRemoteIceCandidates();
     }
   }
 


### PR DESCRIPTION
Cached remote ICE candidate can be added to `PeerConnection` when signaling state is 'have-remote-offer' when current endpoint is answerer, or 'stable' when current endpoint is offerer.