### PR TITLE
Set bundle policy to max-bundle for conference mode.

### DIFF
--- a/src/sdk/conference/channel.js
+++ b/src/sdk/conference/channel.js
@@ -861,6 +861,7 @@ export class ConferencePeerConnectionChannel extends EventDispatcher {
     if (Utils.isChrome()) {
       pcConfiguration.sdpSemantics = 'unified-plan';
     }
+    pcConfiguration.bundlePolicy = 'max-bundle';
     this._pc = new RTCPeerConnection(pcConfiguration);
     this._pc.onicecandidate = (event) => {
       this._onLocalIceCandidate.apply(this, [event]);


### PR DESCRIPTION
Since server supports bundle, we can safely set it to max-bundle. It also fixes the issue that paced sender is paused during renegotiation.

Fixes #435.