### PR TITLE
Set bundle policy to max-bundle on Chrome only.

### DIFF
--- a/src/sdk/conference/channel.js
+++ b/src/sdk/conference/channel.js
@@ -860,8 +860,8 @@ export class ConferencePeerConnectionChannel extends EventDispatcher {
     const pcConfiguration = this._config.rtcConfiguration || {};
     if (Utils.isChrome()) {
       pcConfiguration.sdpSemantics = 'unified-plan';
+      pcConfiguration.bundlePolicy = 'max-bundle';
     }
-    pcConfiguration.bundlePolicy = 'max-bundle';
     this._pc = new RTCPeerConnection(pcConfiguration);
     this._pc.onicecandidate = (event) => {
       this._onLocalIceCandidate.apply(this, [event]);


### PR DESCRIPTION
QA observed an issue when mixing a stream published from Firefox with max-bundle.