### PR TITLE
Use WebTransport instead of QuicTransport.

### DIFF
--- a/docs/design/webtransport.md
+++ b/docs/design/webtransport.md
@@ -18,6 +18,10 @@ Following APIs will be changed to support QuicTransport.
 
 JavaScript SDK creates a QuicTransport with a QUIC agent when QUIC agent is enabled at server side, and WebTransport is supported at client side. When app publishes or subscribes a data stream, a new QuicStream is created.
 
+## Limitations
+
+WebTransport only supported in Chrome since 87. It's not enabled by default. To enable it, you need to [register the origin trail](https://web.dev/webtransport/#register-for-ot) or start Chrome with flag `--enable-experimental-web-platform-features`.
+
 ## Examples
 
 ### Send data to a conference

--- a/docs/jsdoc/config.json
+++ b/docs/jsdoc/config.json
@@ -19,7 +19,7 @@
     "outputSourcePath": false,
     "systemName": "Intel® Collaboration Suite for WebRTC version 5.0",
     "footer": "",
-    "copyright": "Copyright © 2020 Intel Corporation. All Rights Reserved.",
+    "copyright": "Copyright © 2021 Intel Corporation. All Rights Reserved.",
     "navType": "vertical",
     "theme": "cosmo",
     "linenums": true,

--- a/src/sdk/conference/client.js
+++ b/src/sdk/conference/client.js
@@ -416,13 +416,20 @@ export const ConferenceClient = function(config, signalingImpl) {
             }
           }
         }
-        if (typeof QuicTransport === 'function' && token.webTransportUrl) {
+        if (typeof WebTransport === 'function' && token.webTransportUrl) {
           quicTransportChannel = new QuicConnection(
               token.webTransportUrl, resp.webTransportToken,
               createSignalingForChannel(), config.webTransportConfiguration);
         }
-        resolve(new ConferenceInfo(resp.room.id, Array.from(participants
-            .values()), Array.from(remoteStreams.values()), me));
+        const conferenceInfo=new ConferenceInfo(resp.room.id, Array.from(participants
+          .values()), Array.from(remoteStreams.values()), me);
+        if (quicTransportChannel) {
+          quicTransportChannel.init().then(() => {
+            resolve(conferenceInfo);
+          });
+        } else {
+          resolve(conferenceInfo);
+        }
       }, (e) => {
         signalingState = SignalingState.READY;
         reject(new ConferenceError(e));

--- a/src/sdk/conference/client.js
+++ b/src/sdk/conference/client.js
@@ -421,8 +421,9 @@ export const ConferenceClient = function(config, signalingImpl) {
               token.webTransportUrl, resp.webTransportToken,
               createSignalingForChannel(), config.webTransportConfiguration);
         }
-        const conferenceInfo=new ConferenceInfo(resp.room.id, Array.from(participants
-          .values()), Array.from(remoteStreams.values()), me);
+        const conferenceInfo = new ConferenceInfo(
+            resp.room.id, Array.from(participants.values()),
+            Array.from(remoteStreams.values()), me);
         if (quicTransportChannel) {
           quicTransportChannel.init().then(() => {
             resolve(conferenceInfo);


### PR DESCRIPTION
`QuicTransport` was merged to `WebTransport`. This change updates some calls to comply with the latest spec.

This change also resolves join after authentication is passed for WebTransport.