### PR TITLE
Add AV1 to video codec enumeration.

### DIFF
--- a/src/sdk/base/codec.js
+++ b/src/sdk/base/codec.js
@@ -94,7 +94,7 @@ export const VideoCodec = {
   AV1: 'av1',
   // Non-standard AV1, will be renamed to AV1.
   // https://bugs.chromium.org/p/webrtc/issues/detail?id=11042
-  AV1X: 'av1x'
+  AV1X: 'av1x',
 };
 
 /**

--- a/src/sdk/base/codec.js
+++ b/src/sdk/base/codec.js
@@ -91,6 +91,10 @@ export const VideoCodec = {
   VP9: 'vp9',
   H264: 'h264',
   H265: 'h265',
+  AV1: 'av1',
+  // Non-standard AV1, will be renamed to AV1.
+  // https://bugs.chromium.org/p/webrtc/issues/detail?id=11042
+  AV1X: 'av1x'
 };
 
 /**


### PR DESCRIPTION
AV1(AV1X) encoder is only available on Chrome >= 90.