### PR TITLE
Send localDescription, not local variable

### DIFF
--- a/src/sdk/p2p/peerconnection-channel.js
+++ b/src/sdk/p2p/peerconnection-channel.js
@@ -852,7 +852,7 @@ class P2PPeerConnectionChannel extends EventDispatcher {
       localDesc = desc;
       if (this._pc.signalingState === 'stable') {
         return this._pc.setLocalDescription(desc).then(() => {
-          return this._sendSdp(localDesc);
+          return this._sendSdp(this._pc.localDescription);
         });
       }
     }).catch((e) => {
@@ -873,7 +873,7 @@ class P2PPeerConnectionChannel extends EventDispatcher {
       this._logCurrentAndPendingLocalDescription();
       return this._pc.setLocalDescription(desc);
     }).then(()=>{
-      return this._sendSdp(localDesc);
+      return this._sendSdp(this._pc.localDescription);
     }).catch((e) => {
       Logger.error(e.message + ' Please check your codec settings.');
       const error = new ErrorModule.P2PError(ErrorModule.errors.P2P_WEBRTC_SDP,

--- a/src/sdk/p2p/peerconnection-channel.js
+++ b/src/sdk/p2p/peerconnection-channel.js
@@ -846,10 +846,8 @@ class P2PPeerConnectionChannel extends EventDispatcher {
       return;
     }
     this._isNegotiationNeeded = false;
-    let localDesc;
     this._pc.createOffer().then((desc) => {
       desc.sdp = this._setRtpReceiverOptions(desc.sdp);
-      localDesc = desc;
       if (this._pc.signalingState === 'stable') {
         return this._pc.setLocalDescription(desc).then(() => {
           return this._sendSdp(this._pc.localDescription);
@@ -866,10 +864,8 @@ class P2PPeerConnectionChannel extends EventDispatcher {
   _createAndSendAnswer() {
     this._drainPendingStreams();
     this._isNegotiationNeeded = false;
-    let localDesc;
     this._pc.createAnswer().then((desc) => {
       desc.sdp = this._setRtpReceiverOptions(desc.sdp);
-      localDesc=desc;
       this._logCurrentAndPendingLocalDescription();
       return this._pc.setLocalDescription(desc);
     }).then(()=>{


### PR DESCRIPTION
Sending the argument passed to setLocalDescription() is not always the correct thing to do, if there are new offers incoming or a rollback occurred. Instead, send the PeerConnection's localDescription (not current or pending, PeerConnection knows which to use)