### PR TITLE
Subscribed streams are associated with subscriptions.

### DIFF
--- a/docs/mdfiles/changelog.md
+++ b/docs/mdfiles/changelog.md
@@ -1,5 +1,7 @@
 Change Log
 ==========
+# 5.1
+* When subscribe a stream in conference mode, the subscribed MediaStream or BidirectionalStream is associated with a `Owt.Conference.Subscription` instead of a `Owt.Base.RemoteStream`. The `stream` property of a RemoteStream in conference mode is always undefined, while a new property `stream` is added to `Subscription`. It allows a RemoteStream to be subscribed multiple times, as well as subscribing audio and video tracks from different streams.
 # 5.0
 * Add WebTransport support for conference mode, see [this design doc](../../design/webtransport.md) for detailed information.
 * All publications and subscriptions for the same conference use the same `PeerConnection`.

--- a/src/samples/conference/public/scripts/index.js
+++ b/src/samples/conference/public/scripts/index.js
@@ -94,7 +94,7 @@ const runSocketIOSample = function() {
             }).then((
                 subscription) => {
                     subscirptionLocal = subscription;
-                $(`#${stream.id}`).get(0).srcObject = stream.mediaStream;
+                $(`#${stream.id}`).get(0).srcObject = subscription.stream;
             });
         }
         let $p = createResolutionButtons(stream, subscribeDifferentResolution);
@@ -102,7 +102,7 @@ const runSocketIOSample = function() {
         .then((subscription)=>{
             subscirptionLocal = subscription;
             let $video = $(`<video controls autoplay id=${stream.id} style="display:block" >this browser does not supported video tag</video>`);
-           $video.get(0).srcObject = stream.mediaStream;
+           $video.get(0).srcObject = subscription.stream;
            $p.append($video);
         }, (err)=>{ console.log('subscribe failed', err);
         });

--- a/src/sdk/base/stream.js
+++ b/src/sdk/base/stream.js
@@ -149,7 +149,9 @@ export class LocalStream extends Stream {
 }
 /**
  * @class RemoteStream
- * @classDesc Stream sent from a remote endpoint.
+ * @classDesc Stream sent from a remote endpoint. In conference mode,
+ * RemoteStream's stream is always undefined. Please get MediaStream or
+ * ReadableStream from subscription's stream property.
  * Events:
  *
  * | Event Name      | Argument Type    | Fired when         |

--- a/src/sdk/conference/subscription.js
+++ b/src/sdk/conference/subscription.js
@@ -270,7 +270,7 @@ export class SubscriptionUpdateOptions {
  */
 export class Subscription extends EventDispatcher {
   // eslint-disable-next-line require-jsdoc
-  constructor(id, stop, getStats, mute, unmute, applyOptions) {
+  constructor(id, stream, stop, getStats, mute, unmute, applyOptions) {
     super();
     if (!id) {
       throw new TypeError('ID cannot be null or undefined.');
@@ -284,6 +284,19 @@ export class Subscription extends EventDispatcher {
       configurable: false,
       writable: false,
       value: id,
+    });
+    /**
+     * @member {MediaStream | BidirectionalStream} stream
+     * @instance
+     * @memberof Owt.Conference.Subscription
+     */
+    Object.defineProperty(this, 'stream', {
+      configurable: false,
+      // TODO: It should be a readonly property, but current implementation
+      // creates Subscription after receiving 'ready' from server. At this time,
+      // MediaStream may not be available.
+      writable: true,
+      value: stream,
     });
     /**
      * @function stop
@@ -328,5 +341,10 @@ export class Subscription extends EventDispatcher {
      * @returns {Promise<undefined, Error>}
      */
     this.applyOptions = applyOptions;
+
+    // Track is not defined in server protocol. So these IDs are equal to their
+    // stream's ID at this time.
+    this._audioTrackId = undefined;
+    this._videoTrackId = undefined;
   }
 }


### PR DESCRIPTION
When subscribe a stream in conference mode, the subscribed stream no
longer associated with RemoteStream. It allows a RemoteStream to be
subscribed multiple times. It also allows a subscription has audio and
video track from different remote streams.

Since the signaling protocol defined by server side does not provide an
ID for a track, the SDK usually use stream ID + track kind to identify a
track. The stream ID and track ID mentioned in conference mode indicate
the ID assigned by conference sever, they could be different from
MediaStream ID and MediaStreamTrack ID.