### PR TITLE
Publish with RTCRtpTransceivers.

### DIFF
--- a/docs/design/owt_with_webrtc_apis.md
+++ b/docs/design/owt_with_webrtc_apis.md
@@ -11,8 +11,8 @@ OWT(Open WebRTC Toolkit) Client SDKs provide convenient APIs to create, publish,
 #### API Changes
 - A new member `rtpTransceivers` will be added to `TransportSettings`. It returns an array `RTCRtpReceiver`s for RTP transport.
 - A new member `transport` will be added to `Publication` and `Subscription`. Developers could get `RTPTransceiver`s from its `rtpTransceivers` property.
-- A new method `addTransceiver(DOMString trackKind, sequence<RTCRtpEncodingParameters> sendEncodings)` will be added to `ConferenceClient`. It invokes `RTCPeerConnection.addTransceiver(trackKind, {direction:inactive, sendEncodings:sendEncodings})`, returns an `RTCRtpTransceiver`. Please note that direction is `inactive` until a `publish` with return transceiver is called.
-- The second parameter of `ConferenceClient.publish` accepts an `RTCRtpTransceiver` created by `RTCPeerConnection.addTransceiver`. When this method is called, certain `RTCRtpTransceiver`'s direction is changed to `sendonly`, and its sender's `setStreams` is called with the first parameter's `mediaStream`.
+- A new member `peerConnection` will be added to `ConferenceClient` for developers to get the `PeerConnection`.
+- The second parameter of `ConferenceClient.publish` accepts an `RTCRtpTransceiver` created by `RTCPeerConnection.addTransceiver`. `RTCRtpTransceiver`s' direction must be `sendonly`, and its sender's `setStreams` is called with the first parameter's `mediaStream`.
 #### Server Requirements
 - `addTransceiver` and new `publish` needs renegotiation support.
 #### Remarks

--- a/docs/design/owt_with_webrtc_apis.md
+++ b/docs/design/owt_with_webrtc_apis.md
@@ -42,7 +42,7 @@ for (const track of mediaStream.getTracks()) {
   }
   transceivers.push(transceiver);
 }
-const publication = await conference.publish(localStream, transceivers));
+const publication = await conference.publish(localStream, transceivers);
 ```
 
 

--- a/docs/design/owt_with_webrtc_apis.md
+++ b/docs/design/owt_with_webrtc_apis.md
@@ -1,19 +1,71 @@
 # OWT SDK with WebRTC APIs
 ## Introduction
 OWT(Open WebRTC Toolkit) Client SDKs provide convenient APIs to create, publish, and subscribe streams. Most of these APIs are wrappers of WebRTC APIs with signaling support. It helps WebRTC beginners easily involve WebRTC technology into their applications without too much knowledge of WebRTC evolution and browser differences. As WebRTC 1.0 is moving to PR, which means it is quite stable, we are planning to expose more WebRTC APIs to developers to enable advanced and custom usages with OWT.
-## WebRTC APIs
-### RTCRtpTransceiver, RTCRtpSender, RTCRtpReceiver
-#### Potential Usages
+## Potential Usages
 - Replace a track in the middle of a call.
 - Set custom encoding parameters, perhaps for simulcast.
 - Set preferred codecs.
 - Disable or enable RTX / RED / FEC.
-#### API Changes
+## API Changes
 - A new member `rtpTransceivers` will be added to `TransportSettings`. It returns an array `RTCRtpReceiver`s for RTP transport.
 - A new member `transport` will be added to `Publication` and `Subscription`. Developers could get `RTPTransceiver`s from its `rtpTransceivers` property.
 - A new member `peerConnection` will be added to `ConferenceClient` for developers to get the `PeerConnection`.
 - The second parameter of `ConferenceClient.publish` accepts an `RTCRtpTransceiver` created by `RTCPeerConnection.addTransceiver`. `RTCRtpTransceiver`s' direction must be `sendonly`, and its sender's `setStreams` is called with the first parameter's `mediaStream`.
-#### Server Requirements
+## Server Requirements
 - `addTransceiver` and new `publish` needs renegotiation support.
-#### Remarks
+## Remarks
 - Every transceiver could be associated with at most one `Publication` or one `Subscription`.
+## Examples
+### Replace a video track
+```
+const transceivers = publication.transport.rtpTransceivers;
+for (const transceiver of transceivers) {
+  if (transceiver.sender.track?.kind === 'video'){
+    transceiver.sender.replaceTrack(newTrack);
+  }
+}
+```
+
+### Publish a stream with codec preferences
+```
+const codecCapabilities = RTCRtpSender.getCapabilities('video').codecs;
+// Reorder codecCapabilities or remove some items.
+const transceivers = [];
+for (const track of mediaStream.getTracks()) {
+  const transceiver =
+      conference.peerConnection.addTransceiver(track, {
+        direction: 'sendonly',
+        streams: [stream],
+      });
+  if (track.kind==='video'){
+      transceiver.setCodecPreferences(codecCapabilities);
+  }
+  transceivers.push(transceiver);
+}
+const publication = await conference.publish(localStream, transceivers));
+```
+
+
+### Publish with a codec supports SVC.
+This example uses some WebRTC APIs may not be supported by all browsers.
+```
+const transceiver =
+    conference.peerConnection.addTransceiver(track, {
+      direction: 'sendonly',
+      streams: [stream],
+      sendEncodings: [
+        {
+          rid: 'q',
+          scaleResolutionDownBy: 4.0,
+          scalabilityMode: 'L1T3'
+        },
+        {
+          rid: 'h',
+          scaleResolutionDownBy: 2.0,
+          scalabilityMode: 'L1T3'
+        },
+        {rid: 'f', scalabilityMode: 'L1T3'}
+      ],
+    });
+const publication = await conference.publish(localStream, [transceiver]));
+```

--- a/docs/mdfiles/changelog.md
+++ b/docs/mdfiles/changelog.md
@@ -4,6 +4,8 @@ Change Log
 * When subscribe a stream in conference mode, the subscribed MediaStream or BidirectionalStream is associated with a `Owt.Conference.Subscription` instead of a `Owt.Base.RemoteStream`. The `stream` property of a RemoteStream in conference mode is always undefined, while a new property `stream` is added to `Subscription`. It allows a RemoteStream to be subscribed multiple times, as well as subscribing audio and video tracks from different streams.
 * Add a new property `transport` to `Publication` for getting `TransportSettings`.
 * Add a new property `rtpTransceivers` to `TransportSettings` and `TransportConstraints`.
+* Add a new property `peerConnection` to `ConferenceClient`.
+* The second argument of `ConferenceClient.publish` could be a list of `RTCRtpTransceiver`s.
 # 5.0
 * Add WebTransport support for conference mode, see [this design doc](../../design/webtransport.md) for detailed information.
 * All publications and subscriptions for the same conference use the same `PeerConnection`.

--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -4,7 +4,7 @@
 {
   "extends": ["eslint:recommended", "google", "webrtc"],
   "parserOptions": {
-    "ecmaVersion": 2018,
+    "ecmaVersion": 2020,
     "sourceType": "module"
   },
   "rules": {

--- a/src/samples/conference/public/scripts/index.js
+++ b/src/samples/conference/public/scripts/index.js
@@ -29,6 +29,9 @@
 'use strict';
 var conference;
 var publicationGlobal;
+// Change to your sample server's URL if it's not deployed on the same machine
+// as this page.
+const serverUrlBase = undefined;
 const runSocketIOSample = function() {
 
     let localStream;
@@ -124,7 +127,7 @@ const runSocketIOSample = function() {
         console.log('A new stream is added ', event.stream.id);
         isSelf = isSelf?isSelf:event.stream.id != publicationGlobal.id;
         subscribeForward && isSelf && subscribeAndRenderVideo(event.stream);
-        mixStream(myRoom, event.stream.id, 'common');
+        mixStream(myRoom, event.stream.id, 'common', serverUrlBase);
         event.stream.addEventListener('ended', () => {
             console.log(event.stream.id + ' is ended.');
         });
@@ -144,7 +147,7 @@ const runSocketIOSample = function() {
                 myId = resp.self.id;
                 myRoom = resp.id;
                 if(mediaUrl){
-                     startStreamingIn(myRoom, mediaUrl);
+                     startStreamingIn(myRoom, mediaUrl, serverUrlBase);
                 }
                 if (isPublish !== 'false') {
                     // audioConstraintsForMic
@@ -174,9 +177,22 @@ const runSocketIOSample = function() {
                             mediaStream, new Owt.Base.StreamSourceInfo(
                                 'mic', 'camera'));
                         $('.local video').get(0).srcObject = stream;
+                        // Publish with RTCRtpTransceivers.
+                        // const transceivers = [];
+                        // for (const track of mediaStream.getTracks()) {
+                        //   transceivers.push(
+                        //       conference.peerConnection.addTransceiver(track, {
+                        //         direction: 'sendonly',
+                        //         streams: [stream],
+                        //       }));
+                        // }
+                        // publication =
+                        //     await conference.publish(localStream, transceivers);
+
+                        // Publish with options.
                         conference.publish(localStream, publishOption).then(publication => {
                             publicationGlobal = publication;
-                            mixStream(myRoom, publication.id, 'common')
+                            mixStream(myRoom, publication.id, 'common', serverUrlBase)
                             publication.addEventListener('error', (err) => {
                                 console.log('Publication error: ' + err.error.message);
                             });
@@ -216,7 +232,7 @@ const runSocketIOSample = function() {
                     $p.appendTo($('body'));
                 }
             });
-        });
+        }, serverUrlBase);
     };
 };
 window.onbeforeunload = function(event){

--- a/src/sdk/conference/channel.js
+++ b/src/sdk/conference/channel.js
@@ -34,12 +34,12 @@ export class ConferencePeerConnectionChannel extends EventDispatcher {
   // eslint-disable-next-line require-jsdoc
   constructor(config, signaling) {
     super();
+    this.pc = null;
     this._config = config;
     this._videoCodecs = undefined;
     this._options = null;
     this._videoCodecs = undefined;
     this._signaling = signaling;
-    this._pc = null;
     this._internalId = null; // It's publication ID or subscription ID.
     this._pendingCandidates = [];
     this._subscribePromises = new Map(); // internalId => { resolve, reject }
@@ -210,7 +210,7 @@ export class ConferencePeerConnectionChannel extends EventDispatcher {
 
     const offerOptions = {};
     const transceivers = [];
-    if (typeof this._pc.addTransceiver === 'function') {
+    if (typeof this.pc.addTransceiver === 'function') {
       // |direction| seems not working on Safari.
       if (mediaOptions.audio && stream.mediaStream.getAudioTracks().length >
         0) {
@@ -221,7 +221,7 @@ export class ConferencePeerConnectionChannel extends EventDispatcher {
         if (this._isRtpEncodingParameters(options.audio)) {
           transceiverInit.sendEncodings = options.audio;
         }
-        const transceiver = this._pc.addTransceiver(
+        const transceiver = this.pc.addTransceiver(
             stream.mediaStream.getAudioTracks()[0],
             transceiverInit);
         transceivers.push({
@@ -248,7 +248,7 @@ export class ConferencePeerConnectionChannel extends EventDispatcher {
           transceiverInit.sendEncodings = options.video;
           this._videoCodecs = videoCodecs;
         }
-        const transceiver = this._pc.addTransceiver(
+        const transceiver = this.pc.addTransceiver(
             stream.mediaStream.getVideoTracks()[0],
             transceiverInit);
         transceivers.push({
@@ -270,13 +270,13 @@ export class ConferencePeerConnectionChannel extends EventDispatcher {
       if (mediaOptions.audio &&
           stream.mediaStream.getAudioTracks().length > 0) {
         for (const track of stream.mediaStream.getAudioTracks()) {
-          this._pc.addTrack(track, stream.mediaStream);
+          this.pc.addTrack(track, stream.mediaStream);
         }
       }
       if (mediaOptions.video &&
           stream.mediaStream.getVideoTracks().length > 0) {
         for (const track of stream.mediaStream.getVideoTracks()) {
-          this._pc.addTrack(track, stream.mediaStream);
+          this.pc.addTrack(track, stream.mediaStream);
         }
       }
       offerOptions.offerToReceiveAudio = false;
@@ -285,9 +285,9 @@ export class ConferencePeerConnectionChannel extends EventDispatcher {
     this._publishTransceivers.set(internalId, {transceivers});
 
     let localDesc;
-    this._pc.createOffer(offerOptions).then((desc) => {
+    this.pc.createOffer(offerOptions).then((desc) => {
       localDesc = desc;
-      return this._pc.setLocalDescription(desc);
+      return this.pc.setLocalDescription(desc);
     }).then(() => {
       const trackOptions = [];
       transceivers.forEach(({type, transceiver, source}) => {
@@ -455,10 +455,10 @@ export class ConferencePeerConnectionChannel extends EventDispatcher {
     const offerOptions = {};
     const transceivers = [];
     this._createPeerConnection();
-    if (typeof this._pc.addTransceiver === 'function') {
+    if (typeof this.pc.addTransceiver === 'function') {
       // |direction| seems not working on Safari.
       if (mediaOptions.audio) {
-        const transceiver = this._pc.addTransceiver(
+        const transceiver = this.pc.addTransceiver(
             'audio', {direction: 'recvonly'});
         transceivers.push({
           type: 'audio',
@@ -468,7 +468,7 @@ export class ConferencePeerConnectionChannel extends EventDispatcher {
         });
       }
       if (mediaOptions.video) {
-        const transceiver = this._pc.addTransceiver(
+        const transceiver = this.pc.addTransceiver(
             'video', {direction: 'recvonly'});
         transceivers.push({
           type: 'video',
@@ -485,9 +485,9 @@ export class ConferencePeerConnectionChannel extends EventDispatcher {
     this._subscribeTransceivers.set(internalId, {transceivers});
 
     let localDesc;
-    this._pc.createOffer(offerOptions).then((desc) => {
+    this.pc.createOffer(offerOptions).then((desc) => {
       localDesc = desc;
-      return this._pc.setLocalDescription(desc)
+      return this.pc.setLocalDescription(desc)
           .catch((errorMessage) => {
             Logger.error('Set local description failed. Message: ' +
                 JSON.stringify(errorMessage));
@@ -564,8 +564,8 @@ export class ConferencePeerConnectionChannel extends EventDispatcher {
   }
 
   close() {
-    if (this._pc && this._pc.signalingState !== 'closed') {
-      this._pc.close();
+    if (this.pc && this.pc.signalingState !== 'closed') {
+      this.pc.close();
     }
   }
 
@@ -616,9 +616,9 @@ export class ConferencePeerConnectionChannel extends EventDispatcher {
       }
       // Clean transceiver
       transceivers.forEach(({transceiver}) => {
-        if (this._pc.signalingState === 'stable') {
+        if (this.pc.signalingState === 'stable') {
           transceiver.sender.replaceTrack(null);
-          this._pc.removeTrack(transceiver.sender);
+          this.pc.removeTrack(transceiver.sender);
         }
       });
       this._publishTransceivers.delete(internalId);
@@ -748,7 +748,7 @@ export class ConferencePeerConnectionChannel extends EventDispatcher {
 
   _onLocalIceCandidate(event) {
     if (event.candidate) {
-      if (this._pc.signalingState !== 'stable') {
+      if (this.pc.signalingState !== 'stable') {
         this._pendingCandidates.push(event.candidate);
       } else {
         this._sendCandidate(event.candidate);
@@ -780,8 +780,8 @@ export class ConferencePeerConnectionChannel extends EventDispatcher {
     if (!error) {
       error = new ConferenceError('Connection failed or closed.');
     }
-    if (this._pc && this._pc.iceConnectionState !== 'closed') {
-      this._pc.close();
+    if (this.pc && this.pc.iceConnectionState !== 'closed') {
+      this.pc.close();
     }
 
     // Rejecting all corresponding promises if publishing and subscribing is ongoing.
@@ -814,9 +814,9 @@ export class ConferencePeerConnectionChannel extends EventDispatcher {
   }
 
   _onConnectionStateChange(event) {
-    if (this._pc.connectionState === 'closed' ||
-        this._pc.connectionState === 'failed') {
-      if (this._pc.connectionState === 'failed') {
+    if (this.pc.connectionState === 'closed' ||
+        this.pc.connectionState === 'failed') {
+      if (this.pc.connectionState === 'failed') {
         this._handleError('connection failed.');
       } else {
         // Fire ended event if publication or subscription exists.
@@ -840,7 +840,7 @@ export class ConferencePeerConnectionChannel extends EventDispatcher {
   }
 
   _createPeerConnection() {
-    if (this._pc) {
+    if (this.pc) {
       return;
     }
 
@@ -848,24 +848,24 @@ export class ConferencePeerConnectionChannel extends EventDispatcher {
     if (Utils.isChrome()) {
       pcConfiguration.bundlePolicy = 'max-bundle';
     }
-    this._pc = new RTCPeerConnection(pcConfiguration);
-    this._pc.onicecandidate = (event) => {
+    this.pc = new RTCPeerConnection(pcConfiguration);
+    this.pc.onicecandidate = (event) => {
       this._onLocalIceCandidate.apply(this, [event]);
     };
-    this._pc.ontrack = (event) => {
+    this.pc.ontrack = (event) => {
       this._onRemoteStreamAdded.apply(this, [event]);
     };
-    this._pc.oniceconnectionstatechange = (event) => {
+    this.pc.oniceconnectionstatechange = (event) => {
       this._onIceConnectionStateChange.apply(this, [event]);
     };
-    this._pc.onconnectionstatechange = (event) => {
+    this.pc.onconnectionstatechange = (event) => {
       this._onConnectionStateChange.apply(this, [event]);
     };
   }
 
   _getStats() {
-    if (this._pc) {
-      return this._pc.getStats();
+    if (this.pc) {
+      return this.pc.getStats();
     } else {
       return Promise.reject(new ConferenceError(
           'PeerConnection is not available.'));
@@ -922,7 +922,7 @@ export class ConferencePeerConnectionChannel extends EventDispatcher {
 
   _sdpHandler(sdp) {
     if (sdp.type === 'answer') {
-      this._pc.setRemoteDescription(sdp).then(() => {
+      this.pc.setRemoteDescription(sdp).then(() => {
         if (this._pendingCandidates.length > 0) {
           for (const candidate of this._pendingCandidates) {
             this._sendCandidate(candidate);

--- a/src/sdk/conference/client.js
+++ b/src/sdk/conference/client.js
@@ -145,7 +145,7 @@ export const ConferenceClient = function(config, signalingImpl) {
   Object.defineProperty(this, 'transport', {
     configurable: false,
     writable: false,
-    value: this.peerConnectionChannel.pc,
+    value: this.peerConnectionChannel?.pc,
   });
 
   /**
@@ -463,8 +463,8 @@ export const ConferenceClient = function(config, signalingImpl) {
    * @instance
    * @desc Publish a LocalStream to conference server. Other participants will be able to subscribe this stream when it is successfully published.
    * @param {Owt.Base.LocalStream} stream The stream to be published.
-   * @param {Owt.Base.PublishOptions} options Options for publication.
-   * @param {string[]} videoCodecs Video codec names for publishing. Valid values are 'VP8', 'VP9' and 'H264'. This parameter only valid when options.video is RTCRtpEncodingParameters. Publishing with RTCRtpEncodingParameters is an experimental feature. This parameter is subject to change.
+   * @param {(Owt.Base.PublishOptions|RTPTransceiver[])} options If options is a PublishOptions, the stream will be published as options specified. If options is a list of RTPTransceivers, each track in the first argument must have a corresponding RTPTransceiver here, and the track will be published with the RTPTransceiver associated with it.
+   * @param {string[]} videoCodecs Video codec names for publishing. Valid values are 'VP8', 'VP9' and 'H264'. This parameter only valid when the second argument is PublishOptions and options.video is RTCRtpEncodingParameters. Publishing with RTCRtpEncodingParameters is an experimental feature. This parameter is subject to change.
    * @return {Promise<Publication, Error>} Returned promise will be resolved with a newly created Publication once specific stream is successfully published, or rejected with a newly created Error if stream is invalid or options cannot be satisfied. Successfully published means PeerConnection is established and server is able to process media data.
    */
   this.publish = function(stream, options, videoCodecs) {

--- a/src/sdk/conference/client.js
+++ b/src/sdk/conference/client.js
@@ -142,10 +142,11 @@ export const ConferenceClient = function(config, signalingImpl) {
    * @memberof Owt.Conference.ConferenceClient
    * @see {@link https://w3c.github.io/webrtc-pc/#rtcpeerconnection-interface|RTCPeerConnection Interface of WebRTC 1.0}.
    */
-  Object.defineProperty(this, 'transport', {
+  Object.defineProperty(this, 'peerConnection', {
     configurable: false,
-    writable: false,
-    value: this.peerConnectionChannel?.pc,
+    get() {
+      return peerConnectionChannel?.pc;
+    },
   });
 
   /**
@@ -463,7 +464,7 @@ export const ConferenceClient = function(config, signalingImpl) {
    * @instance
    * @desc Publish a LocalStream to conference server. Other participants will be able to subscribe this stream when it is successfully published.
    * @param {Owt.Base.LocalStream} stream The stream to be published.
-   * @param {(Owt.Base.PublishOptions|RTPTransceiver[])} options If options is a PublishOptions, the stream will be published as options specified. If options is a list of RTPTransceivers, each track in the first argument must have a corresponding RTPTransceiver here, and the track will be published with the RTPTransceiver associated with it.
+   * @param {(Owt.Base.PublishOptions|RTCRtpTransceiver[])} options If options is a PublishOptions, the stream will be published as options specified. If options is a list of RTCRtpTransceivers, each track in the first argument must have a corresponding RTCRtpTransceiver here, and the track will be published with the RTCRtpTransceiver associated with it.
    * @param {string[]} videoCodecs Video codec names for publishing. Valid values are 'VP8', 'VP9' and 'H264'. This parameter only valid when the second argument is PublishOptions and options.video is RTCRtpEncodingParameters. Publishing with RTCRtpEncodingParameters is an experimental feature. This parameter is subject to change.
    * @return {Promise<Publication, Error>} Returned promise will be resolved with a newly created Publication once specific stream is successfully published, or rejected with a newly created Error if stream is invalid or options cannot be satisfied. Successfully published means PeerConnection is established and server is able to process media data.
    */


### PR DESCRIPTION
This change allows developers to publish a stream with specific `RTCTransceiver`s. See https://github.com/open-webrtc-toolkit/owt-client-javascript/blob/master/docs/design/owt_with_webrtc_apis.md for detailed design.