### PR TITLE
Publication.rtpTransceivers returns transceivers in P2P mode.

### DIFF
--- a/docs/design/owt_with_webrtc_apis.md
+++ b/docs/design/owt_with_webrtc_apis.md
@@ -1,6 +1,6 @@
 # OWT SDK with WebRTC APIs
 ## Introduction
-OWT(Open WebRTC Toolkit) Client SDKs provide convenient APIs to create, publish, and subscribe streams. Most of these APIs are wrappers of WebRTC APIs with signaling support. It helps WebRTC beginners easily involve WebRTC technology into their applications without too much knowledge of WebRTC evolution and browser differences. As WebRTC 1.0 is moving to PR, which means it is quite stable, we are planning to expose more WebRTC APIs to developers to enable advanced and custom usages with OWT.
+OWT(Open WebRTC Toolkit) Client SDKs provide convenient APIs to create, publish, and subscribe streams. Most of these APIs are wrappers of WebRTC APIs with signaling support. It helps WebRTC beginners easily involve WebRTC technology into their applications without too much knowledge of WebRTC evolution and browser differences. As WebRTC 1.0 was officially made a W3C Recommendation, which means it is stable, we are planning to expose more WebRTC APIs to developers to enable advanced and custom usages with OWT.
 ## Potential Usages
 - Replace a track in the middle of a call.
 - Set custom encoding parameters, perhaps for simulcast.

--- a/src/sdk/p2p/p2pclient.js
+++ b/src/sdk/p2p/p2pclient.js
@@ -257,8 +257,28 @@ const P2PClient = function(configuration, signalingChannel) {
     return channels.get(remoteId).getStats();
   };
 
-  const sendSignalingMessage = function(
-      remoteId, connectionId, type, message) {
+  /**
+   * @function getPeerConnection
+   * @instance
+   * @desc Get underlying PeerConnection.
+   * @memberof Owt.P2P.P2PClient
+   * @param {string} remoteId Remote endpoint's ID.
+   * @return {Promise<RTCPeerConnection, Error>} It returns a promise resolved
+   *     with an RTCPeerConnection or reject with an Error if there is no
+   *     connection with specific user.
+   * @private
+   */
+  this.getPeerConnection = function(remoteId) {
+    if (!channels.has(remoteId)) {
+      return Promise.reject(new ErrorModule.P2PError(
+          ErrorModule.errors.P2P_CLIENT_INVALID_STATE,
+          'No PeerConnection between current endpoint and specific remote ' +
+              'endpoint.'));
+    }
+    return channels.get(remoteId).peerConnection;
+  };
+
+  const sendSignalingMessage = function(remoteId, connectionId, type, message) {
     const msg = {
       type,
       connectionId,

--- a/test/unit/resources/scripts/p2p.js
+++ b/test/unit/resources/scripts/p2p.js
@@ -7,7 +7,8 @@
 import P2PClient from '../../../../src/sdk/p2p/p2pclient.js';
 import SignalingChannel from './fake-p2p-signaling.js';
 import * as StreamModule from '../../../../src/sdk/base/stream.js';
-import * as EventModule from '../../../../src/sdk/base/event.js'
+import * as EventModule from '../../../../src/sdk/base/event.js';
+import {TransportSettings, TransportType} from '../../../../src/sdk/base/transport.js';
 
 const expect = chai.expect;
 const screenSharingExtensionId = 'jniliohjdiikfjjdlpapmngebedgigjn';
@@ -118,6 +119,10 @@ describe('Unit tests for P2PClient', function() {
         p2pclient1.getStats('user2').then((stats)=>{
           console.info('Stats: '+JSON.stringify(stats));
         });
+        expect(p2pclient1.getPeerConnection('user2'))
+                .to.be.an.instanceof(RTCPeerConnection);
+        expect(publication.transport.type === TransportType.WEBRTC);
+        expect(publication.transport.rtpTransceivers.length === 1);
         expect(publication.stop()).to.be.undefined;
         done();
       });


### PR DESCRIPTION
This change also adds an API to get PeerConnection for a given remote
endpoint. Since the P2P mode heavily depends on remote endpoint's
implementation. Using WebRTC APIs directly in P2P mode is not
recommended.