### PR TITLE
Set default log level to error.

### DIFF
--- a/src/sdk/base/logger.js
+++ b/src/sdk/base/logger.js
@@ -96,7 +96,7 @@ const Logger = (function() {
     }
   };
 
-  setLogLevel(DEBUG); // Default level is debug.
+  setLogLevel(ERROR); // Default level.
 
   that.setLogLevel = setLogLevel;
 


### PR DESCRIPTION
Default log level for production environment. If developers want collect
more information, please change log level manually.