### PR TITLE
Check for the transport id

### DIFF
--- a/src/sdk/conference/channel.js
+++ b/src/sdk/conference/channel.js
@@ -1120,8 +1120,9 @@ export class ConferencePeerConnectionChannel extends EventDispatcher {
     if (this._publications.has(message.id)) {
       eventTargets.push(this._publications.get(message.id));
     }
-    for (const subscription of this._subscriptions) {
-      if (message.id === subscription._audioTrackId ||
+    for (const [_key, subscription] of this._subscriptions) {
+      if (message.id === subscription.transport.id ||
+          message.id === subscription._audioTrackId ||
           message.id === subscription._videoTrackId) {
         eventTargets.push(subscription);
       }


### PR DESCRIPTION
Subscriptions is a map and not an array, because of that checking on `subscription._audioTrackId|_videoTrackId` will actually not work.

For some reason, _audioTrackId and _videoTrackId is actually `undefined`. I am not sure if this is a good fix. The issue was caused with this commit: https://github.com/open-webrtc-toolkit/owt-server/issues/1037

For more information, see discussion in https://github.com/open-webrtc-toolkit/owt-server/issues/1037