### PR TITLE
Create PeerConnection when PeerConnectionChannel is created.

### DIFF
--- a/src/sdk/conference/channel.js
+++ b/src/sdk/conference/channel.js
@@ -61,6 +61,8 @@ export class ConferencePeerConnectionChannel extends EventDispatcher {
     this._sdpResolvers = []; // [{finish, resolve, reject}]
     this._sdpResolveNum = 0;
     this._remoteMediaStreams = new Map(); // Key is subscription ID, value is MediaStream.
+
+    this._createPeerConnection();
   }
 
   /**
@@ -223,7 +225,6 @@ export class ConferencePeerConnectionChannel extends EventDispatcher {
       }
     }
     const mediaOptions = {};
-    this._createPeerConnection();
     if (stream.mediaStream.getAudioTracks().length > 0 && options.audio !==
       false && options.audio !== null) {
       if (stream.mediaStream.getAudioTracks().length > 1) {
@@ -511,7 +512,6 @@ export class ConferencePeerConnectionChannel extends EventDispatcher {
 
     const offerOptions = {};
     const transceivers = [];
-    this._createPeerConnection();
     if (typeof this.pc.addTransceiver === 'function') {
       // |direction| seems not working on Safari.
       if (mediaOptions.audio) {
@@ -898,6 +898,7 @@ export class ConferencePeerConnectionChannel extends EventDispatcher {
 
   _createPeerConnection() {
     if (this.pc) {
+      Logger.warning('PeerConnection exists.');
       return;
     }
 

--- a/src/sdk/conference/client.js
+++ b/src/sdk/conference/client.js
@@ -335,7 +335,7 @@ export const ConferenceClient = function(config, signalingImpl) {
   }
 
   // eslint-disable-next-line require-jsdoc
-  function sendSignalingMessage(type, message) {
+  async function sendSignalingMessage(type, message) {
     return signaling.send(type, message);
   }
 

--- a/test/unit/resources/scripts/conference.js
+++ b/test/unit/resources/scripts/conference.js
@@ -88,7 +88,7 @@ describe('Unit tests for ConferencePeerConnectionChannel.', () => {
           false, true
         ]
       ];
-      const channel = new ConferencePeerConnectionChannel();
+      const channel = new ConferencePeerConnectionChannel({});
       for (const [p, isRtpEncodingParameters, isOwtEncodingParameters] of
                parameters) {
         expect(channel._isRtpEncodingParameters(p))


### PR DESCRIPTION
This change allows application to get `PeerConnection` before publishing or subscribing. Then the application can create `RTCRtpTransceiver`s on the `PeerConnection` returned, and publish a stream with `RTCRtpTransceiver`s pre-configurated.