### PR TITLE
Fix `mute` and `unmute` event triggering multiple times

### DIFF
--- a/src/sdk/conference/client.js
+++ b/src/sdk/conference/client.js
@@ -161,9 +161,9 @@ export const ConferenceClient = function(config, signalingImpl) {
         // Broadcast audio/video update status to channel so specific events can be fired on publication or subscription.
         if (data.data.field === 'audio.status' || data.data.field ===
           'video.status') {
-          channels.forEach((c) => {
-            c.onMessage(notification, data);
-          });
+          if (mainChannel) {
+            mainChannel.onMessage(notification, data);
+          }
         } else if (data.data.field === 'activeInput') {
           fireActiveAudioInputChange(data);
         } else if (data.data.field === 'video.layout') {


### PR DESCRIPTION
Fix mute and unmute events getting dispatched multiple times.

Now that a single channel is used for publication and subscription, we should trigger stream update related events only once for the main channel.

Related to #514 